### PR TITLE
Add minifigure support to base plate / roadways

### DIFF
--- a/LEGO Examples.scad
+++ b/LEGO Examples.scad
@@ -1,6 +1,18 @@
 use <LEGO.scad>;
 
 rotate([0, 0, 180]) union() {
+    color("gray") place(0, -14) uncenter(-4, 0) rotate([0, 0, 90]) block(
+        type="brick",
+        roadway_mode="minifig",
+        width=4,
+        length=3,
+        height=1/3,
+        roadway_width=1,
+        roadway_length=2,
+        roadway_y=1,
+        roadway_x=1
+    );
+
     place(-4, -12) uncenter(22, 6) rotate([0, 0, 90]) block(
         type="baseplate",
         width=6,
@@ -9,8 +21,7 @@ rotate([0, 0, 180]) union() {
         roadway_length=6,
         roadway_x=12
     );
-    
-    //place(0, 0, 13/96) {
+        //place(0, 0, 13/96) {
         color( "yellow" ) place(-5, -5, 0) uncenter(1/3, 15, 4) rotate([90, 0, 0]) block(
             dual_sided=true,
             width=4,

--- a/LEGO.scad
+++ b/LEGO.scad
@@ -83,6 +83,9 @@ roadway_x = 0;
 // Where should the roadway start (y-value)? A value of zero puts the roadway at the front of the plate.
 roadway_y = 0;
 
+// Should the road be inverted? Useful for minifigure display with one row of studs on the middle.
+roadway_mode = "road"; // [road:Road, minifig:Minifig]
+
 /* [SNOT] */
 
 // SNOT means Studs Not On Top -- bricks with alternative stud configurations.
@@ -132,6 +135,7 @@ translate([0, 0, (block_type == "tile" ? block_height_ratio * block_height : 0)]
         roadway_length=roadway_length,
         roadway_x=roadway_x,
         roadway_y=roadway_y,
+        roadway_mode=roadway_mode,
         stud_rescale=stud_rescale,
         stud_top_roundness=stud_top_roundness,
         dual_sided=(dual_sided=="yes"),
@@ -164,6 +168,7 @@ module block(
     roadway_length=0,
     roadway_x=0,
     roadway_y=0,
+    roadway_mode="road",
     stud_rescale=1,
     stud_top_roundness=0,
     dual_sided=false,
@@ -834,7 +839,9 @@ module block(
             )
         )
         ||
-        (real_roadway_width > 0 && real_roadway_length > 0 && pos_in_roadway(xcount, ycount))
+        (roadway_mode == "road" && real_roadway_width > 0 && real_roadway_length > 0 && pos_in_roadway(xcount, ycount))
+        ||
+        (roadway_mode == "minifig" && real_roadway_width > 0 && real_roadway_length > 0 && !pos_in_roadway(xcount, ycount))
     );
 
     function pos_in_roadway(x, y) = (

--- a/LEGO.scad
+++ b/LEGO.scad
@@ -815,21 +815,6 @@ module block(
         )
     );
     
-    function put_stud_here(xcount, ycount) = (
-        (type != "wing" && real_roadway_width > 0 && real_roadway_length > 0)
-        ||
-        (type == "wing" && (
-            (wing_type == "full" && (ycount+1 > ceil(width_loss(xcount+1)/2)) && (ycount+1 <= floor(real_width - (width_loss(xcount+1)/2))))
-            || (wing_type == "left" && ycount+1 <= wing_width(xcount+1))
-            || (wing_type == "right" && ycount >= width_loss(xcount+1))
-            )
-        )
-        ||
-        (real_roadway_width == 0 && real_roadway_length == 0)
-        ||
-        (!pos_in_roadway(xcount, ycount))
-    );
-    
     function put_vertical_axle_hole_here(xcount, ycount) = (
         !skip_this_axle_hole(xcount, ycount)
     );


### PR DESCRIPTION
I was trying to come up with this model using your library:
https://minifigs.me/products/little-black-baseplate-custom-printed-lego-baseplate?variant=24139359551552

Basically inverting the functionality of the roadways feature that you already have.

Separated some dead code deletion in another commit, that method is not used anymore, not sure if by design or by accident.