### PR TITLE
adds ender 3 pro pla stud rescale

### DIFF
--- a/LEGO.scad
+++ b/LEGO.scad
@@ -102,6 +102,7 @@ use_reinforcement = "no"; // [no:No, yes:Yes]
 
 // If your printer prints the blocks correctly except for the stud diameter, use this variable to resize just the studs for your printer. A value of 1.05 will print the studs 105% wider than standard.
 stud_rescale = 1.00;
+//stud_rescale = 1.03 * 1;  // Creality Ender 3 Pro, PLA
 //stud_rescale = 1.0475 * 1; // Orion Delta, T-Glase
 //stud_rescale = 1.022 * 1; // Orion Delta, ABS
 


### PR DESCRIPTION
I don't know how long you want the printer list to get but this was the factor I found for my printer. I also found I needed to turn wall splines off to fit original LEGO studs into these blocks. Happy to keep these changes to my fork if this would junk up your repo too much.

Thanks for creating this. It was easy to find and perfect for making a few odd custom blocks I need for my wall-mounted lego phone charger. :-)