### PR TITLE
Allow for 1 1/2 bricks. Allows replicating some stock Duplo parts.

### DIFF
--- a/LEGO.scad
+++ b/LEGO.scad
@@ -13,7 +13,7 @@ block_width = 2;
 block_length = 6;
 
 // Height of the block. A ratio of "1" is a standard LEGO brick height; a ratio of "1/3" is a standard LEGO plate height; "1/2" is a standard DUPLO plate.
-block_height_ratio = 1; // [.33333333333:1/3, .5:1/2, 1:1, 2:2, 3:3, 4:4, 5:5, 6:6, 7:7, 8:8, 9:9, 10:10]
+block_height_ratio = 1; // [.33333333333:1/3, .5:1/2, 1:1, 1.5:1 1/2, 2:2, 3:3, 4:4, 5:5, 6:6, 7:7, 8:8, 9:9, 10:10]
 
 // What type of block should this be? For type-specific options, see the "Wings," "Slopes," "Curves", and "Baseplates" tabs.
 block_type = "brick"; // [brick:Brick, tile:Tile, wing:Wing, slope:Slope, curve:Curve, baseplate:Baseplate, round:Round]


### PR DESCRIPTION
Incredibly simply change.

I noticed that I couldn't generate `11170 - Duplo Brick 2 x 2 x 1 1/2 with Curved Top` or `11169  Duplo Brick 2 x 2 x 1 1/2 with Curve`.

The stock curve doesn't match those quite right, but I thought it was worth adding.


