### PR TITLE
Add measurements for Duplo axles.

### DIFF
--- a/LEGO.scad
+++ b/LEGO.scad
@@ -208,9 +208,11 @@ module block(
 
     roof_thickness = (type == "baseplate" || dual_sided ? block_height * height : 1 * 1);
 
+    // Duplo axle dimensions are based on "Early Simple Machines Set 9656"
+    axle_spline_width = (brand == "lego" ? 2.0 : 3.10);
+    axle_diameter = (brand == "lego" ? 5 * 1 : 7.25);
+
     // Brand-independent measurements.
-    axle_spline_width = 2.0;
-    axle_diameter = 5 * 1;
     wall_play = 0.1 * 1;
     horizontal_hole_wall_thickness = 1 * 1;
 


### PR DESCRIPTION
This pull request changes the axle dimensions for Duplo axles to match the "Early Simple Machines Set 9656" originally used as an education set. I measured the inner diameter of an original piece I had on hand and printed a test piece. An original axle fits perfectly.

I debated a more complicated set up where you could switch between Duplo and Technic axle dimensions, but I think that for myself and the majority of users, this is what is expected.

I wanted to print this piece to build a windmill.

![20230117_092315-COLLAGE](https://user-images.githubusercontent.com/2071543/212939239-0f4cb2af-dd63-4146-9fea-a14899b3ae8f.jpg)
