### PR TITLE
Increase Duplo stud diameter by 0.05 mm to more closely match stock part

### DIFF
--- a/LEGO.scad
+++ b/LEGO.scad
@@ -187,7 +187,7 @@ module block(
     ) {
     post_wall_thickness = (brand == "lego" ? 0.85 : 1);
     wall_thickness=(brand == "lego" ? 1.45 : 1.5);
-    stud_diameter=(brand == "lego" ? 4.85 : 9.35);
+    stud_diameter=(brand == "lego" ? 4.85 : 9.40);
     hollow_stud_inner_diameter = (brand == "lego" ? 3.1 : 6.7);
     stud_height=(brand == "lego" ? 1.8 : 4.4);
     stud_spacing=(brand == "lego" ? 8 : 8 * 2);


### PR DESCRIPTION
This is an incredibly small change. Prior to this change, Duplo blocks fit together more loosely than I would like, both printed parts against stock parts and printed parts against other printed parts.

I measured the studs with my calipers and this was the only dimension that was off by more than 0.01 (error on the calipers). I changed this and did a test print to confirm that the fit is better. With the change, Duplo pieces fit together more tightly, closer subjectively to "stock".

![PXL_20230117_171331046~2](https://user-images.githubusercontent.com/2071543/212967055-8629ae33-4252-4d21-b9a1-366768182dfe.jpg)

