### PR TITLE
stud matrix to explicitly draw or omit stud positions

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,6 @@ The `block` module is most basic module, able to generate most basic parts.
 | `stud_matrix_columns` | int| How many columns per row in the stud matrix string? Not directly related to the size of the baseplate.|
 | `stud_matrix_invert` | `true`, `false` | Should the stud matrix be inverted? Asterisk for studs to be removed.|
 | `stud_matrix_swapxy` | `true`, `false` | Overall drawing has the larger dimension horizontal. Use this to quickly swap the X and Y understanding of the stud matrix.|
-
 | `round_radius` | int | How many studs should be rounded at the corners?|
 | `round_stud_notches` | `yes`, `no` | Should the rounded edges be notched to accept studs below?|
 | `dual_sided` | `yes`, `no` | SNOT means Studs Not On Top -- bricks with alternative stud configurations. Put studs on the top and bottom? |

--- a/README.md
+++ b/README.md
@@ -46,6 +46,11 @@ The `block` module is most basic module, able to generate most basic parts.
 | `roadway_x` | int| Where should the roadway start (x-value)?|
 | `roadway_y` | int| Where should the roadway start (y-value)?|
 | `roadway_invert` | `true`, `false` | Should the road be inverted? Useful for minifigure display with one row of studs on the middle. |
+| `stud_matrix_string` | string| A single string representing rows of stud positions. See comments in the source file for how this works.|
+| `stud_matrix_columns` | int| How many columns per row in the stud matrix string? Not directly related to the size of the baseplate.|
+| `stud_matrix_invert` | `true`, `false` | Should the stud matrix be inverted? Asterisk for studs to be removed.|
+| `stud_matrix_swapxy` | `true`, `false` | Overall drawing has the larger dimension horizontal. Use this to quickly swap the X and Y understanding of the stud matrix.|
+
 | `round_radius` | int | How many studs should be rounded at the corners?|
 | `round_stud_notches` | `yes`, `no` | Should the rounded edges be notched to accept studs below?|
 | `dual_sided` | `yes`, `no` | SNOT means Studs Not On Top -- bricks with alternative stud configurations. Put studs on the top and bottom? |


### PR DESCRIPTION
Repeating from source comments:

// The stud matrix is a collection of (x,y) positions to explicity
// draw (or omit) selected studs.  Naturally, it's also clipped by the
// brick itself (no Studs in Space-ace-ce-e!). This isn't that useful
// for making real bricks, but it's handy for some specialized
// situations.

// The interaction with a roadway can be a little tricky to
// understand, particularly with inversion of either. So either figure
// things out experimentally or stick with just a stud matrix or just
// a roadway, but not both.

// It would be nice if we could just parameterize a list of (X,Y)
// positions to define the stud matrix, but the OpenSCAD customizer
// doesn't have a way to do that. Instead, we define the matrix as a
// single string representing a collection of rows, with each
// character representing a column position in the row. The rows in
// the string are all the same length, but that can be different from
// either dimension of the brick.

// An asterisk (*) means "yes" and any other character means "no". To
// make the string more readable, you might like to define
// stud_matrix_columns to be an extra column wide so you can use a
// space to visually separate the logical rows in the string. Any
// (X,y) position that is beyond the end of a logical row in the
// string or beyond the entire string is taken as not having an
// asterisk in that position. That way, you can define just enough
// string to get the studs you want without having to cover the entire
// brick dimensions. For example, you could supply the string
// "*.*.* .***." with a stud_matrix_columns value of 6.