### PR TITLE
Wall splines rescale

### DIFF
--- a/LEGO.scad
+++ b/LEGO.scad
@@ -187,6 +187,7 @@ module block(
     stud_type="solid",
     block_bottom_type="open",
     include_wall_splines=true,
+    wall_splines_rescale=1.0,
     horizontal_holes=false,
     vertical_axle_holes=false,
     reinforcement=false,
@@ -224,7 +225,7 @@ module block(
     reinforcing_width = (brand == "lego" ? 0.7 : 1);
 
     real_include_wall_splines = block_bottom_type == "open" && include_wall_splines;
-    spline_length = (brand == "lego" ? 0.25 : 1.7);
+    spline_length = (brand == "lego" ? 0.25 : 1.7) * wall_splines_rescale;
     spline_thickness = (brand == "lego" ? 0.7 : 1.3);
 
     horizontal_hole_diameter = (brand == "lego" ? 4.8 : 4.8 * 2);
@@ -685,6 +686,7 @@ module block(
                     stud_type=stud_type,
                     block_bottom_type=block_bottom_type,
                     include_wall_splines=include_wall_splines,
+		    wall_splines_rescale=wall_splines_rescale,
                     horizontal_holes=real_horizontal_holes,
                     vertical_axle_holes=real_vertical_axle_holes,
                     reinforcement=real_reinforcement,

--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ The `block` module is most basic module, able to generate most basic parts.
 | `stud_type` | `solid`, `hollow` | What stud type do you want? Hollow studs allow rods to be pushed into the stud.|
 | `block_bottom_type` | `open`, `closed` | Open blocks are the standard, closed bottom blocks can be used for stacking composite shapes.|
 | `include_wall_splines` | `yes`, `no` | Should the block wall include splines? Valid only for an open block bottom type.|
+| `wall_splines_rescale` | float | Rescale factor to resize the splines length on the walls. A value of 0.9 will print the walls splines with 90% of the standard length. |
 | `horizontal_holes` | `yes`, `no` | Should the block include round horizontal holes like the Technics LEGO bricks have?|
 | `vertical_axle_holes` | `yes`, `no` | Should the block include vertical cross-shaped axle holes?                                  |
 | `wing_type` | `full`, `left`, `right` | What type of wing? Full is suitable for the front of a plane, left/right are for the left/right of a plane. |


### PR DESCRIPTION
Add the ability to rescale wall splines. When I print the brick with a height of 1 with standard wall splines, the printed part does not fit the original Lego parts. When I turn off splines, the printed part does not hold on to the original Lego parts. With my Bambu Lab A1 mini, I use `stud_rescale=1.03` and `wall_splines_rescale=0.3` for the best result.